### PR TITLE
fix(mtx1): support partial frameHeader overrides in frame toBytes fun…

### DIFF
--- a/src/mtx1/utils/frame.ts
+++ b/src/mtx1/utils/frame.ts
@@ -22,10 +22,11 @@ export interface IInvalidMtxFrame {
 export type TMtxFrame = IMtxFrame | IInvalidMtxFrame;
 
 
-export const toBytes = ( message: TBytes, frameHeader: IFrameHeader = defaultFrameHeader ): TBytes => {
+export const toBytes = ( message: TBytes, frameHeader?: Partial<IFrameHeader> ): TBytes => {
     const buffer: IBinaryBuffer = new BinaryBuffer(frameHeaderSize, false);
+    const resolvedFrameHeader: IFrameHeader = {...defaultFrameHeader, ...frameHeader};
 
-    setFrameHeader(buffer, frameHeader);
+    setFrameHeader(buffer, resolvedFrameHeader);
 
     return frame.toBytes(buffer.data.concat(message));
 };


### PR DESCRIPTION
This code would be cleaner. No need to import defaultFrameHeader

import * as frameCoder from 'jooby-codec/mtx1/utils/frame.js';
import {defaultFrameHeader} from 'jooby-codec/mtx1/utils/binary/buffer.js';

const frame = frameCoder.toBytes(bytes, {...defaultFrameHeader, ...header});