### PR TITLE
feat(mtx3): add legacy GetCurrentValuesResponse compatibility

### DIFF
--- a/src/mtx3/commands/uplink/getCurrentValues.ts
+++ b/src/mtx3/commands/uplink/getCurrentValues.ts
@@ -44,7 +44,7 @@
 
 import * as types from '../../types.js';
 import * as command from '../../../mtx1/utils/command.js';
-import {validateRangeCommandPayload} from '../../../utils/validateCommandPayload.js';
+import {validateSetCommandPayload} from '../../../utils/validateCommandPayload.js';
 import {READ_ONLY} from '../../../mtx1/constants/accessLevels.js';
 import * as dlms from '../../constants/dlms.js';
 import BinaryBuffer, {IBinaryBuffer} from '../../../utils/binary/BinaryBuffer.js';
@@ -213,7 +213,7 @@ export const examples: command.TCommandExamples = {
  * @returns command payload
  */
 export const fromBytes = ( bytes: types.TBytes ): IGetCurrentValuesResponseParameters => {
-    validateRangeCommandPayload(name, bytes, {min: minSize, max: maxSize});
+    validateSetCommandPayload(name, bytes, [minSize, maxSize]);
 
     const buffer: IBinaryBuffer = new BinaryBuffer(bytes, false);
     const hasNeutral = bytes.length === maxSize;

--- a/src/mtx3/commands/uplink/getCurrentValues.ts
+++ b/src/mtx3/commands/uplink/getCurrentValues.ts
@@ -44,7 +44,7 @@
 
 import * as types from '../../types.js';
 import * as command from '../../../mtx1/utils/command.js';
-import validateCommandPayload from '../../../utils/validateCommandPayload.js';
+import {validateRangeCommandPayload} from '../../../utils/validateCommandPayload.js';
 import {READ_ONLY} from '../../../mtx1/constants/accessLevels.js';
 import * as dlms from '../../constants/dlms.js';
 import BinaryBuffer, {IBinaryBuffer} from '../../../utils/binary/BinaryBuffer.js';
@@ -116,7 +116,7 @@ export interface IGetCurrentValuesResponseParameters {
     /**
      * Current in neutral (`91.7.0`).
      */
-    iNeutral: types.TInt32
+    iNeutral?: types.TInt32
 }
 
 
@@ -124,11 +124,12 @@ export const id: types.TCommandId = commandId;
 export const name: types.TCommandName = commandNames[commandId];
 export const headerSize = 2;
 export const accessLevel: types.TAccessLevel = READ_ONLY;
+export const minSize = 48;
 export const maxSize = 52;
 export const isLoraOnly = false;
 
 export const examples: command.TCommandExamples = {
-    'simple response': {
+    'response with neutral': {
         id,
         name,
         maxSize,
@@ -165,6 +166,42 @@ export const examples: command.TCommandExamples = {
             0x00, 0x03, 0x20, 0xc8,
             0x00, 0x00, 0x05, 0xdc
         ]
+    },
+    'response without neutral': {
+        id,
+        name,
+        maxSize: minSize,
+        headerSize,
+        accessLevel,
+        parameters: {
+            vaRms: 230000,
+            vbRms: 231000,
+            vcRms: 229000,
+            iaRms: 5000,
+            ibRms: 4900,
+            icRms: 5050,
+            powerA: 1150000,
+            powerB: 1120000,
+            powerC: 1160000,
+            varA: 200000,
+            varB: 195000,
+            varC: 205000
+        },
+        bytes: [
+            0x0d, 0x30,
+            0x00, 0x03, 0x82, 0x70,
+            0x00, 0x03, 0x86, 0x58,
+            0x00, 0x03, 0x7e, 0x88,
+            0x00, 0x00, 0x13, 0x88,
+            0x00, 0x00, 0x13, 0x24,
+            0x00, 0x00, 0x13, 0xba,
+            0x00, 0x11, 0x8c, 0x30,
+            0x00, 0x11, 0x17, 0x00,
+            0x00, 0x11, 0xb3, 0x40,
+            0x00, 0x03, 0x0d, 0x40,
+            0x00, 0x02, 0xf9, 0xb8,
+            0x00, 0x03, 0x20, 0xc8
+        ]
     }
 };
 
@@ -176,11 +213,12 @@ export const examples: command.TCommandExamples = {
  * @returns command payload
  */
 export const fromBytes = ( bytes: types.TBytes ): IGetCurrentValuesResponseParameters => {
-    validateCommandPayload(name, bytes, maxSize);
+    validateRangeCommandPayload(name, bytes, {min: minSize, max: maxSize});
 
     const buffer: IBinaryBuffer = new BinaryBuffer(bytes, false);
+    const hasNeutral = bytes.length === maxSize;
 
-    return {
+    const result: IGetCurrentValuesResponseParameters = {
         vaRms: buffer.getInt32(),
         vbRms: buffer.getInt32(),
         vcRms: buffer.getInt32(),
@@ -192,9 +230,14 @@ export const fromBytes = ( bytes: types.TBytes ): IGetCurrentValuesResponseParam
         powerC: buffer.getInt32(),
         varA: buffer.getInt32(),
         varB: buffer.getInt32(),
-        varC: buffer.getInt32(),
-        iNeutral: buffer.getInt32()
+        varC: buffer.getInt32()
     };
+
+    if ( hasNeutral ) {
+        result.iNeutral = buffer.getInt32();
+    }
+
+    return result;
 };
 
 
@@ -205,7 +248,10 @@ export const fromBytes = ( bytes: types.TBytes ): IGetCurrentValuesResponseParam
  * @returns full message (header with body)
  */
 export const toBytes = ( parameters: IGetCurrentValuesResponseParameters ): types.TBytes => {
-    const buffer: IBinaryBuffer = new BinaryBuffer(maxSize, false);
+    const buffer: IBinaryBuffer = new BinaryBuffer(
+        parameters.iNeutral != null ? maxSize : minSize,
+        false
+    );
 
     // body
     buffer.setInt32(parameters.vaRms);
@@ -220,7 +266,10 @@ export const toBytes = ( parameters: IGetCurrentValuesResponseParameters ): type
     buffer.setInt32(parameters.varA);
     buffer.setInt32(parameters.varB);
     buffer.setInt32(parameters.varC);
-    buffer.setInt32(parameters.iNeutral);
+
+    if ( parameters.iNeutral != null ) {
+        buffer.setInt32(parameters.iNeutral);
+    }
 
     return command.toBytes(id, buffer.data);
 };
@@ -240,9 +289,12 @@ export const toJson = ( parameters: IGetCurrentValuesResponseParameters, options
         '71.7.0': parameters.icRms,
         '1.21.7.0': parameters.powerA,
         '1.41.7.0': parameters.powerB,
-        '1.61.7.0': parameters.powerC,
-        '91.7.0': parameters.iNeutral
+        '1.61.7.0': parameters.powerC
     };
+
+    if ( parameters.iNeutral != null ) {
+        result['91.7.0'] = parameters.iNeutral;
+    }
 
     const varAKey = parameters.varA >= 0 ? '1.23.7.0' : '1.24.7.0';
     const varBKey = parameters.varB >= 0 ? '1.43.7.0' : '1.44.7.0';

--- a/tests/mtx3/dlms/get.current.values.test.ts
+++ b/tests/mtx3/dlms/get.current.values.test.ts
@@ -4,39 +4,72 @@ import {getCurrentValues} from '../../../src/mtx3/commands/uplink/index.js';
 import {runCommandDlmsTest} from '../../mtx1/dlms/utils/runCommandDlmsTest.js';
 
 
-const example = {
-    name: 'getCurrentValues',
-    parameters: {
-        vaRms: 230000,
-        vbRms: 231000,
-        vcRms: 229000,
-        iaRms: 5000,
-        ibRms: 4900,
-        icRms: 5050,
-        powerA: 1150000,
-        powerB: 1120000,
-        powerC: 1160000,
-        varA: 200000,
-        varB: 195000,
-        varC: 205000,
-        iNeutral: 1500
+const examples = [
+    {
+        name: 'getCurrentValues with neutral current',
+        parameters: {
+            vaRms: 230000,
+            vbRms: 231000,
+            vcRms: 229000,
+            iaRms: 5000,
+            ibRms: 4900,
+            icRms: 5050,
+            powerA: 1150000,
+            powerB: 1120000,
+            powerC: 1160000,
+            varA: 200000,
+            varB: 195000,
+            varC: 205000,
+            iNeutral: 1500
+        },
+        dlms: {
+            '32.7.0': 230000,
+            '52.7.0': 231000,
+            '72.7.0': 229000,
+            '31.7.0': 5000,
+            '51.7.0': 4900,
+            '71.7.0': 5050,
+            '1.21.7.0': 1150000,
+            '1.41.7.0': 1120000,
+            '1.61.7.0': 1160000,
+            '91.7.0': 1500,
+            '1.23.7.0': 200000,
+            '1.43.7.0': 195000,
+            '1.63.7.0': 205000
+        }
     },
-    dlms: {
-        '32.7.0': 230000,
-        '52.7.0': 231000,
-        '72.7.0': 229000,
-        '31.7.0': 5000,
-        '51.7.0': 4900,
-        '71.7.0': 5050,
-        '1.21.7.0': 1150000,
-        '1.41.7.0': 1120000,
-        '1.61.7.0': 1160000,
-        '91.7.0': 1500,
-        '1.23.7.0': 200000,
-        '1.43.7.0': 195000,
-        '1.63.7.0': 205000
+    {
+        name: 'getCurrentValues without neutral current',
+        parameters: {
+            vaRms: 230000,
+            vbRms: 231000,
+            vcRms: 229000,
+            iaRms: 5000,
+            ibRms: 4900,
+            icRms: 5050,
+            powerA: 1150000,
+            powerB: 1120000,
+            powerC: 1160000,
+            varA: 200000,
+            varB: 195000,
+            varC: 205000
+        },
+        dlms: {
+            '32.7.0': 230000,
+            '52.7.0': 231000,
+            '72.7.0': 229000,
+            '31.7.0': 5000,
+            '51.7.0': 4900,
+            '71.7.0': 5050,
+            '1.21.7.0': 1150000,
+            '1.41.7.0': 1120000,
+            '1.61.7.0': 1160000,
+            '1.23.7.0': 200000,
+            '1.43.7.0': 195000,
+            '1.63.7.0': 205000
+        }
     }
-};
+];
 
 
-describe('GetCurrentValuesResponse dlms tests', () => runCommandDlmsTest(getCurrentValues, [example]));
+describe('GetCurrentValuesResponse dlms tests', () => runCommandDlmsTest(getCurrentValues, examples));

--- a/tests/mtx3/message.test.ts
+++ b/tests/mtx3/message.test.ts
@@ -93,16 +93,31 @@ const uplinkMessages: TMessageList = [
         destination: 0xaaaa
     },
     {
-        name: 'getCurrentValues',
+        name: 'getCurrentValues with neutral',
         hex: '0a 13 ff 1a 78 5a c9 f1 27 a6 22 6a c8 2f 2d dd d8 dc d8 fa 47 ff df 8e d4 55 6a b4 84 aa 73 5a 04 13 52 ab cf e2 61 65 b0 7e 52 d3 7a 1b 73 34 6c f9 92 5f 1c cc f9 5a d9 98 88 e8 8b 2a 5a b7 17 b4',
         frameHex: '7e 51 aa aa ff ff 0a 7d 33 ff 1a 78 5a c9 f1 27 a6 22 6a c8 2f 2d dd d8 dc d8 fa 47 ff df 8e d4 55 6a b4 84 aa 73 5a 04 7d 33 52 ab cf e2 61 65 b0 7d 5e 52 d3 7a 1b 73 34 6c f9 92 5f 1c cc f9 5a d9 98 88 e8 8b 2a 5a b7 17 b4 ef a9 7e',
         messageId: 10,
         accessLevel: uplinkCommands.getCurrentValues.accessLevel,
         commands: [
-            uplinkCommands.getCurrentValues.examples['simple response']
+            uplinkCommands.getCurrentValues.examples['response with neutral']
         ],
         lrc: 0xd5,
         crc: 0xa9ef,
+        frameType: frameTypes.DATA_RESPONSE,
+        source: 0xffff,
+        destination: 0xaaaa
+    },
+    {
+        name: 'getCurrentValues without neutral',
+        hex: '0a 13 6f 9d d0 d1 90 94 af 47 48 c5 a1 ca 05 e6 29 5a d8 fa 47 ff df 8e d4 55 6a b4 84 aa 73 5a 04 13 52 ab cf e2 61 65 b0 7e 52 d3 7a 1b 73 34 6c f9 5c e7 7d 89 9c 6b 52 b8 76 01 d2 73 60 e8 c4 e8',
+        frameHex: '7e 51 aa aa ff ff 0a 7d 33 6f 9d d0 d1 90 94 af 47 48 c5 a1 ca 05 e6 29 5a d8 fa 47 ff df 8e d4 55 6a b4 84 aa 73 5a 04 7d 33 52 ab cf e2 61 65 b0 7d 5e 52 d3 7a 1b 73 34 6c f9 5c e7 7d 5d 89 9c 6b 52 b8 76 01 d2 73 60 e8 c4 e8 c9 27 7e',
+        messageId: 10,
+        accessLevel: uplinkCommands.getCurrentValues.accessLevel,
+        commands: [
+            uplinkCommands.getCurrentValues.examples['response without neutral']
+        ],
+        lrc: 0x08,
+        crc: 0x27c9,
         frameType: frameTypes.DATA_RESPONSE,
         source: 0xffff,
         destination: 0xaaaa


### PR DESCRIPTION
- accept payloads with or without neutral current
- make neutral current optional during serialization